### PR TITLE
fix typo

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -153,7 +153,7 @@ Thanks for contributing!
 
 This is just to help you organize your process
 
-- [ ] Did I cut my work branch off of master (don't cut new branches from existing feature brances)?
+- [ ] Did I cut my work branch off of master (don't cut new branches from existing feature branches)?
 - [ ] Did I follow the correct naming convention for my branch?
 - [ ] Is my branch focused on a single main change?
 - [ ] Do all of my changes directly relate to this change?


### PR DESCRIPTION
not sure if this is the appropriate branch name.
since it's a documentation typo, it seemed to me to be the best option.

curious, if the typo was in a code file, what would be the appropriate branch name to make this fix?

it's not a document, and not exactly a bug.  
I might opt for 'bug' if it was text displayed to the user..?  
and either 'bug' or 'doc' othewise.. ?

Thanks, Sheryl
